### PR TITLE
fix the cloudant-upload.js username picking up window OS username ins…

### DIFF
--- a/cloudant.md
+++ b/cloudant.md
@@ -47,7 +47,8 @@
     `npm install`
 
     `node cloudant-upload.js`
-
+    
+(in some windows env, the above js may not work because L#8 "  account: process.env.username," in cloudant-upload.js may pick up the OS username instead of the "username" in the .env.json. When this happens, you can change username --> username1 in both cloudant-upload.js and .env.json. Then it will work fine.) 
 
       ![IBM Sign up](assets/cloudant-upload-script.jpg)
 


### PR DESCRIPTION
…tead of bluemix cloudant username

When I debug it, the debugger show username ="cheer" (which is part of my  OS username instead of the bluemix cloudant username inside the .env.json, then it will fail. Seems a bug in dotenv-json package when running in Windows ?

Workaround : change "username" --> "username1" in both cloudant-upload.js and .env.json files.

![cloudant-nodejs-error-debug1](https://user-images.githubusercontent.com/1834997/47480491-7aa64600-d7e5-11e8-95c8-6c90aebc44d0.jpg)
